### PR TITLE
fix(bodyParserCommonErrorsTypes): remove dupe

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,6 @@ function isBodyParserError (error) {
     'stream.encoding.set',
     'parameters.too.many',
     'charset.unsupported',
-    'encoding.unsupported',
     'entity.too.large'
   ]
   return bodyParserCommonErrorsTypes.includes(error.type)


### PR DESCRIPTION
`'encoding.unsupported'` Was duplicated in the error code array