### PR TITLE
Types: Mark all options as optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,8 +2,8 @@ declare module 'express-body-parser-error-handler' {
 	import type { Request, Response, NextFunction } from 'express';
 
 	export interface BodyParserErrorHandlerOptions {
-		onError: (err: Error, req: Request, res: Response) => void;
-		errorMessage: (err: Error) => string;
+		onError?: (err: Error, req: Request, res: Response) => void;
+		errorMessage?: (err: Error) => string;
 	}
 
 	export default function bodyParserErrorHandler(


### PR DESCRIPTION
These types align more closely with the code. Before it was necessary to define both `onError` and `errorMessage` in order to pass the type check. Now you can define either without the other