### PR TITLE
Correct typing for error handler

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 declare module 'express-body-parser-error-handler' {
-	import type { Request, Response, NextFunction } from 'express';
+	import type { Request, Response, ErrorRequestHandler } from 'express';
 
 	export interface BodyParserErrorHandlerOptions {
 		onError?: (err: Error, req: Request, res: Response) => void;
@@ -8,5 +8,5 @@ declare module 'express-body-parser-error-handler' {
 
 	export default function bodyParserErrorHandler(
 		options?: BodyParserErrorHandlerOptions,
-	): (req: Request, res: Response, next: NextFunction) => void;
+	): ErrorRequestHandler;
 }


### PR DESCRIPTION
Found another type inconsistency. The previous types were actually for a request handler rather than an error handler. the actual implementation is an error handler (4 arguments, starting with `error`)